### PR TITLE
Emit a disconnected event

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -102,7 +102,11 @@ class RPCClient extends EventEmitter {
         clearTimeout(timeout);
         resolve(this);
       });
-      this.transport.once('close', reject);
+      this.transport.once('close', () => {
+        this.emit("disconnected");
+        this._connectPromise = undefined;
+        reject();
+      });
       this.transport.connect().catch(reject);
     });
     return this._connectPromise;


### PR DESCRIPTION
Emit a disconnected event when the connection promise closes.
Reset the promise at the same time, so that you can reconnect.